### PR TITLE
Feature/33 markdown format fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Command `text-tables.gotoNextCell` (`Text Tables: Go to next cell` in command pallete) inserts new row when applied in last data cell of table.
+- Fixed markdown parser for tables with separator row where separator row has less columns than other row (#33).
 
 ## [0.1.0] - 2018-04-16
 

--- a/src/ttMarkdown.ts
+++ b/src/ttMarkdown.ts
@@ -1,5 +1,6 @@
 import * as tt from './ttTable';
 import * as vscode from 'vscode';
+import { RowType } from './ttTable';
 
 const verticalSeparator = '|';
 const horizontalSeparator = '-';
@@ -20,7 +21,6 @@ export class MarkdownParser implements tt.Parser {
 
             if (this.isSeparatorRow(cleanedString)) {
                 result.addRow(tt.RowType.Separator, []);
-                result.cols.forEach(x => x.width = Math.max(x.width, 3));
                 const startIndex = cleanedString.startsWith(verticalSeparator) ? 1 : 0;
                 const endIndex = cleanedString.length - (cleanedString.endsWith(verticalSeparator) ? 1 : 0);
                 const rowParts = cleanedString.slice(startIndex, endIndex).split('|');
@@ -57,6 +57,10 @@ export class MarkdownParser implements tt.Parser {
                 .map(x => x.trim());
 
             result.addRow(tt.RowType.Data, values);
+        }
+
+        if (result.rows.some(x => x.type === RowType.Separator)) {
+            result.cols.forEach(x => x.width = Math.max(x.width, 3));
         }
 
         return result;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -251,6 +251,25 @@ suite('Commands', () => {
         });
     });
 
+    test('Test "Format under cursor" for markdown', async () => {
+        const input =
+`| 1   |   2     |
+| --- |
+| 4    | 5       |        6 |`;
+
+        const expected =
+`| 1   | 2   |     |
+| --- | --- | --- |
+| 4   | 5   | 6   |`;
+
+        await inTextEditor({language: 'markdown', content: input}, async (_, document) => {
+            await cfg.override({mode: 'markdown'});
+
+            await vscode.commands.executeCommand('text-tables.formatUnderCursor');
+            assert.equal(document.getText(), expected);
+        });
+    });
+
     test('Test "Next Row"', async () => {
         const input =
 `| Row  |


### PR DESCRIPTION
Fixes #33. Problem was caused by parser, which didn't set appropriate column widths when separator row is present in table.