### PR TITLE
Fixed tests when run from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed tests when run from command line.
+
 ## [0.1.5] - 2018-05-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2525,9 +2525,9 @@
             }
         },
         "url-parse": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-            "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
                 "querystringify": "^2.0.0",

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -20,7 +20,8 @@ function move(editor: vscode.TextEditor, line: number, col: number) {
 
 suite('Commands', () => {
     setup(async () => {
-        await vscode.workspace.updateWorkspaceFolders(0, null, {uri: vscode.Uri.parse('.')});
+        vscode.workspace.updateWorkspaceFolders(0, null, {uri: vscode.Uri.parse('.')});
+        await vscode.workspace.saveAll();
     });
 
     test('Test "Create table" for markdown', async () => {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -20,9 +20,19 @@ function move(editor: vscode.TextEditor, line: number, col: number) {
 
 suite('Commands', () => {
     setup(() => {
-        vscode.workspace.updateWorkspaceFolders(0, null, {uri: vscode.Uri.parse('.')});
-
-        return vscode.workspace.saveAll();
+        // For running e2e tests we want to change configuration on the fly, checking different
+        // modes. In order not to mess with global configuration, it's better to create workspace
+        // and work with workspace configuration that overrides any global settings.
+        // Following piece of code checks whether we have workspace or not and creates new workspace
+        // if we don't have it. This check is required because when you run tests from VS Code
+        // directly, there is no workspace created. If you run tests from command line, workspace IS
+        // created. If you have workspace and you call updateWorkspaceFolders, workspace settings
+        // file is changed and next call for settings update will fail with the following error:
+        // Unable to write into workspace settings because the file is dirty. Please save the
+        // workspace settings file first and then try again.
+        if (vscode.workspace.workspaceFolders === undefined) {
+            vscode.workspace.updateWorkspaceFolders(0, null, {uri: vscode.Uri.parse('.')});
+        }
     });
 
     test('Test "Create table" for markdown', async () => {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -45,7 +45,7 @@ suite('Commands', () => {
             await cmd.createTable(2, 2, editor, new MarkdownStringifier());
             assert.equal(document.getText(), expectedResult);
         });
-    });
+    }).timeout(10000);
 
     test('Test "Create table" for org', async () => {
         const expectedResult = `|  |  |

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -19,9 +19,10 @@ function move(editor: vscode.TextEditor, line: number, col: number) {
 }
 
 suite('Commands', () => {
-    setup(async () => {
+    setup(() => {
         vscode.workspace.updateWorkspaceFolders(0, null, {uri: vscode.Uri.parse('.')});
-        await vscode.workspace.saveAll();
+
+        return vscode.workspace.saveAll();
     });
 
     test('Test "Create table" for markdown', async () => {


### PR DESCRIPTION
Small change into tests setup that saves all files in test workspace. Without it 1 test was failing because it was trying to override setting when config file for workspace was dirty.