### PR TITLE
Feature: Toggle the table mode using the status item

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -33,6 +33,15 @@ export function exitContext(editor: vscode.TextEditor, type: ContextType) {
     }
 }
 
+export function toggleContext(editor: vscode.TextEditor, type: ContextType) {
+    const editorState = state.get(editor.document.fileName) || [];
+    if (editorState.indexOf(ContextType.TableMode) >= 0) {
+        exitContext(editor, type);
+    } else {
+        enterContext(editor, type);
+    }
+}
+
 export function restoreContext(editor: vscode.TextEditor) {
     let toEnter: ContextType[] = [];
     // @ts-ignore

--- a/src/context.ts
+++ b/src/context.ts
@@ -64,8 +64,8 @@ class Context {
     setState(isEnabled: boolean) {
         vscode.commands.executeCommand('setContext', this.type, isEnabled);
         if (this.statusItem) {
-            const stateText = isEnabled ? 'On' : 'Off';
-            this.statusItem.text = `${this.title}: ${stateText}`;
+            const stateText = isEnabled ? '$(check)' : '$(x)';
+            this.statusItem.text = `${this.title} ${stateText}`;
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { OrgLocator, OrgParser, OrgStringifier } from './ttOrg';
 import { Locator, Parser, Stringifier, Table } from './ttTable';
 import { MarkdownLocator, MarkdownParser, MarkdownStringifier } from './ttMarkdown';
 import { isUndefined } from 'util';
-import { registerContext, ContextType, enterContext, exitContext, restoreContext } from './context';
+import { registerContext, ContextType, enterContext, exitContext, restoreContext, toggleContext } from './context';
 import * as cfg from './configuration';
 
 let locator: Locator;
@@ -34,6 +34,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 
     const statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     registerContext(ContextType.TableMode, '$(book) Table Mode', statusItem);
+    statusItem.command = 'text-tables.tableModeToggle';
 
     if (configuration.showStatus) {
         statusItem.show();
@@ -63,7 +64,9 @@ export function activate(ctx: vscode.ExtensionContext) {
         (e) => enterContext(e, ContextType.TableMode)));
     ctx.subscriptions.push(vscode.commands.registerTextEditorCommand('text-tables.tableModeOff',
         (e) => exitContext(e, ContextType.TableMode)));
-
+    ctx.subscriptions.push(vscode.commands.registerTextEditorCommand('text-tables.tableModeToggle',
+        (e) => toggleContext(e, ContextType.TableMode)));
+    
     ctx.subscriptions.push(registerTableCommand('text-tables.moveRowDown', cmd.moveRowDown, {format: true}));
     ctx.subscriptions.push(registerTableCommand('text-tables.moveRowUp', cmd.moveRowUp, {format: true}));
     ctx.subscriptions.push(registerTableCommand('text-tables.moveColRight', async (editor, range, table) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export function activate(ctx: vscode.ExtensionContext) {
     loadConfiguration();
 
     const statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-    registerContext(ContextType.TableMode, '$(book) Table Mode', statusItem);
+    registerContext(ContextType.TableMode, 'Table', statusItem);
     statusItem.command = 'text-tables.tableModeToggle';
 
     if (configuration.showStatus) {


### PR DESCRIPTION
Hi,

This PR adds the ability to toggle the table mode from the status item:
fixes https://github.com/rpeshkov/vscode-text-tables/issues/46

I've implemented some more features for the table editor on https://github.com/philipparndt/vscode-text-tables
in case you like to have them I can split them up into different PR's but I don't like to do this work in case you are not interested. The features are:
- EOL character of vscode.TextEditor
- Keep current indentation of the table when formatting
- avoid flicker during forward navigation without change
- Fixed position when using table indent
- Ability to insert a column left to the current position
- Activate on gherkin feature files
- Added command for column deletion


